### PR TITLE
fix: add cross-reference comments to duplicate is_valid_uuid

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -217,6 +217,8 @@ fn extract_session_id(path: &std::path::Path) -> Result<String> {
     Ok(stem.to_string())
 }
 
+// SECURITY: Duplicated in shell.rs for defense-in-depth.
+// If you modify this, update shell.rs and run uuid_cross_reference_tests.
 pub(crate) fn is_valid_uuid(s: &str) -> bool {
     // [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
     let bytes = s.as_bytes();

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -48,6 +48,8 @@ pub fn print_resume_instructions(session: &SessionInfo) {
     println!("{}", format_resume_instructions(session));
 }
 
+// SECURITY: Duplicated from parse.rs. Must remain identical in behavior.
+// If you modify this, update parse.rs and run uuid_cross_reference_tests.
 pub(crate) fn is_valid_uuid(s: &str) -> bool {
     let bytes = s.as_bytes();
     if bytes.len() != 36 {


### PR DESCRIPTION
## Summary

- Adds SECURITY cross-reference comments to `is_valid_uuid` in both `parse.rs` and `shell.rs`
- Directs maintainers to update both copies and run `uuid_cross_reference_tests` when modifying either function
- Consistency test suite already exists in `lib.rs` (added in #20); this completes the safeguards from issue #31 Option 2

Closes #31

## Test plan

- [x] All 135 unit tests pass (`cargo test --lib`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)