### PR TITLE
chore: adopt the shared Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,28 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", ":preserveSemverRanges"],
-  "minimumReleaseAge": "3 days",
-  "schedule": ["before 9am on Monday"],
-  "timezone": "Europe/London",
-  "packageRules": [
-    {
-      "description": "Group all non-major Cargo updates",
-      "matchManagers": ["cargo"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "rust dependencies (non-major)",
-      "groupSlug": "rust-non-major"
-    },
-    {
-      "description": "Automerge Cargo patch updates",
-      "matchManagers": ["cargo"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
-    },
-    {
-      "description": "Group all GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "groupName": "github actions",
-      "groupSlug": "github-actions"
-    }
+  "extends": [
+    "github>ryanlewis/renovate-config",
+    ":preserveSemverRanges"
   ]
 }


### PR DESCRIPTION
Same migration as ryanlewis/rlew.io#35 and ryanlewis/shout-sh#9, config-only.

**Note: this repo was archived on 2026-06-22.** It was temporarily unarchived to land this migration so the whole estate carries the same config, and is being re-archived immediately after merge — if it's ever revived, Renovate picks up the correct policy from day one. Dependabot alerts were enabled as part of this (they pause while archived).

## What changes

- **Cooldown 3 days → 5** (preset is stricter)
- **Cargo runtime patch automerge is dropped** — the old rule had no depType filter, so it automerged runtime dependency patches; preset policy is runtime-never, dev-patch-only
- Majors move behind dashboard approval; `lockFileMaintenance` explicitly off (open PR #50 was exactly that)

## What's preserved

`":preserveSemverRanges"` — already this repo's own choice. Not for downstream consumers (ccsesh isn't on crates.io; distribution is release binaries + brew/winget), but because pinning would rewrite every Cargo.toml requirement to `=x.y.z` for zero benefit — Cargo.lock already pins builds.

## No `.npmrc` here

CI is cargo only (fmt/clippy/test/audit-check). No node anywhere.

https://claude.ai/code/session_01KpxDfrqPwQAYb2RT6mi1qW